### PR TITLE
Feature/bolt enable custom product index definition

### DIFF
--- a/src/AvenueClothing.Installer/umbraco/uCommerce/Install/Helpers/Catalogue.cs
+++ b/src/AvenueClothing.Installer/umbraco/uCommerce/Install/Helpers/Catalogue.cs
@@ -34,8 +34,11 @@ namespace AvenueClothing.Installer.Helpers
 
         private ProductCatalogGroup CreateCatalogGroup()
         {
+            var groupDefinitionType = DefinitionType.SingleOrDefault(x => x.Name == "Product Catalog Groups");
+            var groupDefinition = Definition.SingleOrDefault(x => x.DefinitionType == groupDefinitionType);
             var group = ProductCatalogGroup.SingleOrDefault(c => c.Name == _catalogGroupName) ??
-                        new ProductCatalogGroupFactory().NewWithDefaults(_catalogGroupName);
+                        new ProductCatalogGroupFactory().NewWithDefaults(_catalogGroupName, groupDefinition.Guid);
+
             group.ProductReviewsRequireApproval = true;
             group.Deleted = false;
             group.CreateCustomersAsMembers = false;
@@ -69,9 +72,8 @@ namespace AvenueClothing.Installer.Helpers
 
         private ProductCatalog CreateProductCatalog(ProductCatalogGroup catalogGroup)
         {
-            var definitionType = DefinitionType.FirstOrDefault(x => x.Name== "Product Catalogs");
-            var catalogDefinition = Definition.FirstOrDefault(x => x.DefinitionType == definitionType);
-
+            var catalogDefinitionType = DefinitionType.SingleOrDefault(x => x.Name == "Product Catalogs");
+            var catalogDefinition = Definition.SingleOrDefault(x => x.DefinitionType == catalogDefinitionType);
             var catalog = catalogGroup.ProductCatalogs.SingleOrDefault(c => c.Name == _catalogName) ??
                           new ProductCatalogFactory().NewWithDefaults(catalogGroup, _catalogName, catalogDefinition.Guid);
 

--- a/src/AvenueClothing/AvenueClothing.csproj
+++ b/src/AvenueClothing/AvenueClothing.csproj
@@ -517,7 +517,7 @@
   <ItemGroup>
     <None Include=".bin\node.cmd" />
     <Content Include="css\sass.scss" />
-    <Content Include="umbraco\Ucommerce\Configuration\Indexes\AvenueProductsIndexDefinition.config.default" />
+    <Content Include="umbraco\Ucommerce\Apps\UCommerce.Search.Lucene.Avenue\Configuration\AvenueProductsIndexDefinition.config" />
     <Content Include="web.config">
       <SubType>Designer</SubType>
     </Content>

--- a/src/AvenueClothing/Controllers/CategoryController.cs
+++ b/src/AvenueClothing/Controllers/CategoryController.cs
@@ -48,26 +48,6 @@ namespace AvenueClothing.Controllers
             }
         }
 
-        protected virtual ActionResult RenderView()
-        {
-            Category currentCategory = CatalogContext.CurrentCategory;
-            var categoryViewModel = new CategoryViewModel
-            {
-                Name = currentCategory.DisplayName,
-                Description = currentCategory.Description,
-                CatalogId = currentCategory.ProductCatalog,
-                CategoryId = currentCategory.Guid,
-                Products = MapProductsInCategories(currentCategory)
-            };
-
-            if (!string.IsNullOrEmpty(currentCategory.ImageMediaUrl))
-            {
-                categoryViewModel.BannerImageUrl = currentCategory.ImageMediaUrl;
-            }
-
-            return View("/Views/Catalog.cshtml", categoryViewModel);
-        }
-
         private IList<ProductViewModel> MapProducts(ICollection<Product> productsInCategory)
         {
             IList<ProductViewModel> productViews = new List<ProductViewModel>();

--- a/src/AvenueClothing/umbraco/Ucommerce/Apps/UCommerce.Search.Lucene.Avenue/Configuration/AvenueProductsIndexDefinition.config
+++ b/src/AvenueClothing/umbraco/Ucommerce/Apps/UCommerce.Search.Lucene.Avenue/Configuration/AvenueProductsIndexDefinition.config
@@ -2,7 +2,7 @@
 
 <configuration>
     <components>
-        <component id="AvenueProductsIndexDefinition"
+        <component id="ProductsIndexDefinition"
                    service="UCommerce.Search.IIndexDefinition`1[[UCommerce.Search.Models.Product, UCommerce.Search]], UCommerce.Search"
                    type="AvenueClothing.Search.AvenueProductIndexDefinition, AvenueClothing">
         </component>

--- a/tools/Deploy/DemoStoreDeploy.cmd
+++ b/tools/Deploy/DemoStoreDeploy.cmd
@@ -23,6 +23,8 @@ rem Copy over the store files which will be zipped
 robocopy src\AvenueClothing package\_ToPackage\files uCommerceApiRegistration.cs FacetedQueryStringExtensions.cs *.cshtml *.js *.png *.jpg *.jpeg *.gif *.eot *.svq *.ttf *.woff *.woff2 *.otf /s /FFT /Z /XA:H /W:5 /xf *packages.config
 robocopy src\AvenueClothing\bin package\_ToPackage\files\bin AvenueClothing.dll /FFT /Z /XA:H /W:5
 
+rem Copy AvenueProductsIndexDefinition.config into a separate app
+robocopy src\AvenueClothing\umbraco\Ucommerce\Apps package\_ToPackage\files\umbraco\Ucommerce\Apps /E
 
 rem Copy over the installer files
 robocopy src\AvenueClothing.Installer package\_ToPackage\files *.ascx *.js *.png *.jpg *.jpeg *.gif *.config /s /FFT /Z /XA:H /W:5 /xf *packages.config

--- a/tools/Deploy/Deploy.cmd
+++ b/tools/Deploy/Deploy.cmd
@@ -29,6 +29,7 @@ robocopy "%path1%\Views" "%path2%\Views" /s
 robocopy "%path1%\img" "%path2%\img" /s
 robocopy "%path1%\js" "%path2%\js" /s
 robocopy "%path1%\bin" "%path2%\bin" AvenueClothing.dll
+robocopy "%path1%\bin" "%path2%\bin" AvenueClothing.Installer.dll
 REM robocopy "%path1%\bin" "%path2%\bin" ServiceStack*.*
 
 GOTO :DONE


### PR DESCRIPTION
Solves:
https://app.clubhouse.io/ucommerce/story/9582/test-that-index-ioc-registration-really-supports-customers-wiring-up-different-combinations-of-default-index-definition-and
https://app.clubhouse.io/ucommerce/story/9475/installer-package-for-avenue-clothing

Few bugs encountered along the way, further info can be found within individual commits.