### PR TITLE
Feature/11043 add field displaynames

### DIFF
--- a/src/AvenueClothing/AvenueClothing.csproj
+++ b/src/AvenueClothing/AvenueClothing.csproj
@@ -505,6 +505,8 @@
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
+    <PostBuildEvent>"$(SolutionDir)..\..\Avenue-Clothing-For-Umbraco\tools\deploy\Deploy.cmd" "$(ProjectDir)" "C:\inetpub\u8\Website"
+    </PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/AvenueClothing/Controllers/ProductController.cs
+++ b/src/AvenueClothing/Controllers/ProductController.cs
@@ -7,6 +7,7 @@ using Ucommerce.Infrastructure;
 using Ucommerce.Search;
 using AvenueClothing.Models;
 using Ucommerce;
+using Ucommerce.Infrastructure.Globalization;
 using Ucommerce.Search.Models;
 using Umbraco.Web.Models;
 using Umbraco.Web.Mvc;
@@ -18,7 +19,9 @@ namespace AvenueClothing.Controllers
 		public ITransactionLibrary TransactionLibrary => ObjectFactory.Instance.Resolve<ITransactionLibrary>();
 		public ICatalogContext CatalogContext => ObjectFactory.Instance.Resolve<ICatalogContext>();
 		private ICatalogLibrary CatalogLibrary => ObjectFactory.Instance.Resolve<ICatalogLibrary>();
-
+		private IIndexDefinition<Product> ProductIndexDefinition => ObjectFactory.Instance.Resolve <IIndexDefinition<Product>>();
+		private ILocalizationContext LocalizationContext => ObjectFactory.Instance.Resolve<ILocalizationContext>();
+		
 		[HttpGet]
 		public ActionResult Index(ContentModel model)
 		{
@@ -116,7 +119,8 @@ namespace AvenueClothing.Controllers
 			foreach (var prop in uniqueVariants)
 			{
 				var productPropertiesViewModel = new ProductPropertiesViewModel();
-				productPropertiesViewModel.PropertyName = prop.Key;
+				productPropertiesViewModel.PropertyName = ProductIndexDefinition.FieldDefinitions[prop.Key]
+					.GetDisplayName(LocalizationContext.CurrentCulture.Name);
 
 				foreach (var value in prop.Select(p => p.Value).Distinct())
 				{

--- a/src/AvenueClothing/Search/AvenueProductIndexDefinition.cs
+++ b/src/AvenueClothing/Search/AvenueProductIndexDefinition.cs
@@ -6,16 +6,19 @@ namespace AvenueClothing.Search
     public class AvenueProductIndexDefinition : DefaultProductsIndexDefinition
     {
         public AvenueProductIndexDefinition() : base()
-        
         {
             this.Field(p => p["ShowOnHomepage"], typeof(bool));
-            this.Field(p => p["CollarSize"], typeof(string));
-            this.Field(p => p["ShoeSize"], typeof(string));
-            this.Field(p => p["Colour"], typeof(string));
+            this.Field(p => p["CollarSize"], typeof(string))
+                .DisplayName("Collar Size")
+                .Facet();
+            this.Field(p => p["ShoeSize"], typeof(string))
+                .DisplayName("Shoe Size").Facet();
+            this.Field(p => p["Colour"], typeof(string))
+                .DisplayName("en-GB", "Colour")
+                .DisplayName("en-US", "Color")
+                .DisplayName("Colour")
+                .Facet();
             this.PricesField(p => p.UnitPrices);
-            this.Facet("Colour");
-            this.Facet("CollarSize");
-            this.Facet("ShoeSize");
         }
     }
 }


### PR DESCRIPTION
This PR adds displaynames for product fields to the index definition, and makes sure that they are used for both facets and fields (eg. when picking variants)

This branch is dependent on the next version of Ucommerce, so it requires ucommerce to be of a matching version.

